### PR TITLE
Use port 80 for Ubuntu keyserver

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 mongodb_package: mongodb-org
 mongodb_package_state: present
 mongodb_version: "4.2"
-mongodb_apt_keyserver: keyserver.ubuntu.com
+mongodb_apt_keyserver: 'hkp://keyserver.ubuntu.com:80'
 mongodb_apt_key_id:
   "3.4": "0C49F3730359A14518585931BC711F9BA15703C6"
   "3.6": "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"


### PR DESCRIPTION
As if you are behind a firewall standard keyserver port 11371 may be filtered